### PR TITLE
[WIP] install all apps from iframe, getInstalled from iframe (bug 1003536)

### DIFF
--- a/hearth/media/js/buttons.js
+++ b/hearth/media/js/buttons.js
@@ -254,12 +254,11 @@ define('buttons',
            "Launch" to "Install". */
 
         // Get installed apps to know which apps may have been uninstalled.
-        var r = navigator.mozApps.getInstalled();
-        r.onsuccess = function() {
+        var r = apps.getInstalled().done(function(results) {
             // Build an array of manifests that match the button's data-manifest.
             var installed = [];
-            _.each(r.result, function(val) {
-                installed.push(require('utils').baseurl(val.manifestURL));
+            _.each(results, function(manifestURL) {
+                installed.push(require('utils').baseurl(manifestURL));
             });
 
             $('.button.product').each(function(i, button) {
@@ -273,7 +272,7 @@ define('buttons',
                     $button.removeClass('launch');
                 }
             });
-        };
+        });
     }
 
     return {

--- a/hearth/media/js/marketplace.js
+++ b/hearth/media/js/marketplace.js
@@ -131,16 +131,15 @@ function(_) {
             return;
         }
         // Get list of installed apps and mark as such.
-        var r = navigator.mozApps.getInstalled();
-        r.onsuccess = function() {
+        require('apps').getInstalled().done(function(results) {
             var buttons = require('buttons');
 
             z.apps = {};
-            _.each(r.result, function(val) {
+            _.each(results, function(manifestURL) {
                 buttons.buttonInstalled(
-                    require('utils').baseurl(val.manifestURL), val);
+                    require('utils').baseurl(manifestURL), {manifestURL: manifestURL});
             });
-        };
+        });
     };
     if (capabilities.webApps) {
         z.page.on('loaded', get_installed);


### PR DESCRIPTION
[latest iframe file](http://ngokevin.com/~ngoke/iframe-install.html)

to fix button states, need to query navigator.mozapps.getinstalled from the iframe. Since we don't want our hosted apps and packaged apps installed on two different origins, install everything from the iframe.

WIP because my browser/sim crashes whenever running `require('apps').getInstalled()` with an app already installed.
