### PR TITLE
add localforaged pagination

### DIFF
--- a/hearth/media/js/db.js
+++ b/hearth/media/js/db.js
@@ -113,9 +113,6 @@ define('db', ['defer', 'format', 'localforage', 'log', 'requests', 'urls', 'sett
 
         var def = defer.Deferred();
         var resolved = false;
-        var num_per_page = 10;
-
-        page = page || 0;
 
         localforage.getItem(category_key(slug, page)).then(function(data) {
             if (data && !resolved) {
@@ -125,9 +122,10 @@ define('db', ['defer', 'format', 'localforage', 'log', 'requests', 'urls', 'sett
             }
         });
 
+        page = page || 0;
         var url = urls.api.url('category', slug, {
-            limit: num_per_page,
-            offset: page * num_per_page
+            limit: settings.num_per_page,
+            offset: page * settings.num_per_page
         });
         requests.get(url, true).done(function(data) {
             if (!resolved) {

--- a/hearth/media/js/routes_api_args.js
+++ b/hearth/media/js/routes_api_args.js
@@ -1,10 +1,10 @@
 define('routes_api_args',
-    ['buckets', 'capabilities', 'user_helpers'],
-    function(buckets, caps, user_helpers) {
+    ['buckets', 'capabilities', 'settings', 'user_helpers'],
+    function(buckets, caps, settings, user_helpers) {
 
     var _dev = null;
     var _device = null;
-    var _limit = 10;
+    var _limit = settings.num_per_page;
 
     if (caps.firefoxOS) {
         _dev = _device = 'firefoxos';

--- a/hearth/media/js/settings.js
+++ b/hearth/media/js/settings.js
@@ -164,6 +164,8 @@ define('settings', ['l10n', 'settings_local', 'underscore'],
 
         iframe_installer_src: 'https://marketplace.firefox.com/iframe-install.html',
 
-        offline_msg: gettext('Sorry, you are currently offline. Please try again later.')
+        offline_msg: gettext('Sorry, you are currently offline. Please try again later.'),
+
+        num_per_page: 10,
     });
 });

--- a/hearth/templates/_macros/more_button.html
+++ b/hearth/templates/_macros/more_button.html
@@ -4,3 +4,12 @@
   <div class="spinner alt btn-replace"></div>
 </li>
 {% endmacro %}
+
+{% macro more_button_localforage(key, slug, page) %}
+<li class="loadmore">
+  <button class="button" data-key="{{ key }}" data-slug="{{ slug }}" data-page="{{ page }}">
+    {{ _('More') }}
+  </button>
+  <div class="spinner alt btn-replace"></div>
+</li>
+{% endmacro %}

--- a/hearth/templates/category_yogafire/main.html
+++ b/hearth/templates/category_yogafire/main.html
@@ -3,7 +3,7 @@
 
 {% set source = category or 'all' %}
 
-{% localforage (key='category', slug=category, pluck='objects' if category else 'apps') %}
+{% localforage (key='category', slug=category, pluck='objects' if category else 'apps', paginate='ol.listing') %}
   <ol class="container listing search-listing c">
     {% if not category %}
       <header class="featured-header c">
@@ -17,8 +17,8 @@
     {% endfor %}
 
     {# Render the more button if there's another page of results and we are dealing with a category #}
-    {% if response.meta.next and category %}
-      {{ more_button(response.meta.next) }}
+    {% if category and response.meta.next %}
+      {{ more_button_localforage('category', category, (response.meta.offset / response.meta.limit) + 1) }}
     {% endif %}
   </ol>
 {% placeholder %}


### PR DESCRIPTION
Flow:
- view kicks off to builder to render page
- initial page is rendered, localforage extensions asynchronously fetches data 
- the localforage extension registers an event handler to the More Button, attaches the cached API response
  to the context. This includes the API's response.meta.
- data is fetched and the partial template is rendered with the More Button
- the More Button has data attributes describing what the next page to fetch is, this is done by calculating `response.meta.offset / response.meta.limit + 1`.
- when clicking that, the localforage extension runs again, fetching the next page from localforage, and injects the data into the listing
