### PR TITLE
multi-layer caching into memory, refactor db.js (bug 1012790)

### DIFF
--- a/hearth/media/js/settings.js
+++ b/hearth/media/js/settings.js
@@ -158,7 +158,7 @@ define('settings', ['l10n', 'settings_local', 'underscore'],
         localforage_driver: 'localStorageWrapper',
 
         // URLs to API responses preloaded with the package.
-        offline_homepage: '/db/tarako-featured.json',
+        'offline_tarako-featured': '/db/tarako-featured.json',
         'offline_tarako-games': '/db/tarako-games.json',
         'offline_tarako-tools': '/db/tarako-tools.json',
         'offline_tarako-lifestyle': '/db/tarako-lifestyle.json',


### PR DESCRIPTION
Limits the amount of reads from localForage we make as we browse Marketplace (currently, we hit localForage on every page). This also limits the amount of API hits to one per endpoint per session (and it would still be async).
- Every time we fetch data (from localForage, API, or package), dump it into a JS [Object object].
- Every time we access data, see if it is in the object.
- Re-enable requests.js session caching (we don't need to keep our data THAT up-to-date).
- Combine homepage/category db methods into one, since homepage is similar to a category.
