### PR TITLE
Do not force portrait orientation (bug 844186)

### DIFF
--- a/hearth/manifest.webapp
+++ b/hearth/manifest.webapp
@@ -36,7 +36,6 @@
     "zh-TW": {}
   },
   "name": "Marketplace",
-  "orientation": ["portrait-primary"],
   "origin": "app://packaged.marketplace.firefox.com",
   "permissions": {
     "mobilenetwork": {

--- a/yulelog/manifest.webapp
+++ b/yulelog/manifest.webapp
@@ -38,7 +38,6 @@
         "zh-TW": {}
     },
     "name": "Marketplace",
-    "orientation": ["portrait-primary"],
     "origin": "app://marketplace.firefox.com",
     "permissions": {
         "mobilenetwork": {"description": "To detect mobile carrier and regional information."}


### PR DESCRIPTION
The Yogafire part of this fix, to allow orientation to match device rather than forcing portrait orientation.
